### PR TITLE
支持mm.error(fs, 'readFile')

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -45,6 +45,10 @@ function getCallback(args) {
  * @param {Number} [tiemout], mock async callback timeout, default is 0.
  */
 exports.error = function (mod, method, error, timeout) {
+  if (!error) {
+    error = new Error('mm mock error');
+    error.name = 'MockError';
+  }
   if (typeof error === 'string') {
     error = new Error(error);
     error.name = 'MockError';

--- a/test/mm.test.js
+++ b/test/mm.test.js
@@ -178,6 +178,17 @@ describe('mm.test.js', function () {
       });
     });
 
+    it('should mock error with empty error', function (done) {
+      mm.error(fs, 'readFile');
+      fs.readFile('/etc/hosts', 'utf8', function (err, data) {
+        should.exist(err);
+        err.name.should.equal('MockError');
+        err.message.should.equal('mm mock error');
+        should.not.exist(data);
+        done();
+      });
+    });    
+
     it('should mock error with 500ms timeout', function (done) {
       mm.error(fs, 'readFile', '500ms timeout', 500);
       var start = Date.now();


### PR DESCRIPTION
有时候只需要模拟错误，可以省掉指定的error
