### PR TITLE
Fix Node 0.11 broken.

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -16,7 +16,7 @@ var muk = require('muk');
 var http = require('http');
 var https = require('https');
 var cp = require('child_process');
-var EventEmitter = require('events').EventEmitter;
+var semver = require('semver');
 
 var mock = module.exports = function mock(obj, key, method) {
   return muk.apply(null, arguments);
@@ -45,7 +45,7 @@ function getCallback(args) {
  * @param {Object} mod, module object
  * @param {String} method, mock module object method name.
  * @param {String|Error} error, error string message or error instance.
- * @param {Number} [tiemout], mock async callback timeout, default is 0.
+ * @param {Number} [tiemout], mock async callback timeout, default is 10.
  */
 exports.error = function (mod, method, error, timeout) {
   if (!error) {
@@ -75,7 +75,7 @@ exports.error = function (mod, method, error, timeout) {
  * @param {Object} mod, module object
  * @param {String} method, mock module object method name.
  * @param {Array} datas, return datas array.
- * @param {Number} [tiemout], mock async callback timeout, default is 0.
+ * @param {Number} [tiemout], mock async callback timeout, default is 10.
  */
 exports.datas = function (mod, method, datas, timeout) {
   if (timeout) {
@@ -100,7 +100,7 @@ exports.datas = function (mod, method, datas, timeout) {
  * @param {Object} mod, module object
  * @param {String} method, mock module object method name.
  * @param {Object} data, return data.
- * @param {Number} [tiemout], mock async callback timeout, default is 0.
+ * @param {Number} [tiemout], mock async callback timeout, default is 10.
  */
 exports.data = function (mod, method, data, timeout) {
   return exports.datas(mod, method, [ data ], timeout);
@@ -111,7 +111,7 @@ exports.data = function (mod, method, data, timeout) {
  *
  * @param {Object} mod, module object
  * @param {String} method, mock module object method name.
- * @param {Number} [tiemout], mock async callback timeout, default is 0.
+ * @param {Number} [tiemout], mock async callback timeout, default is 10.
  */
 exports.empty = function (mod, method, timeout) {
   return exports.datas(mod, method, null, timeout);
@@ -120,8 +120,12 @@ exports.empty = function (mod, method, timeout) {
 exports.http = {};
 exports.https = {};
 
-http.__sourceRequest = http.request;
-https.__sourceRequest = https.request;
+getAgent(http).__sourceRequest = getAgent(http).request;
+getAgent(https).__sourceRequest = getAgent(https).request;
+
+function getAgent(mod) {
+  return semver.satisfies(process.version, '>=0.11') ? mod.globalAgent : mod;
+}
 
 function matchURL(options, params) {
   var url = params && params.url || params;
@@ -166,7 +170,7 @@ function mockRequest() {
  * @param {String|Buffer} data, mock response data.
  *   If data is Array, then res will emit `data` event many times.
  * @param {Object} headers, mock response headers.
- * @param {Number} [delay], response delay time, default is 0.
+ * @param {Number} [delay], response delay time, default is 10.
  */
 exports.http.request = function (url, data, headers, delay) {
   return _request.call(this, http, url, data, headers, delay);
@@ -179,7 +183,7 @@ exports.http.request = function (url, data, headers, delay) {
  * @param {String|Buffer} data, mock response data.
  *   If data is Array, then res will emit `data` event many times.
  * @param {Object} headers, mock response headers.
- * @param {Number} [delay], response delay time, default is 0.
+ * @param {Number} [delay], response delay time, default is 10.
  */
 exports.https.request = function (url, data, headers, delay) {
   return _request.call(this, https, url, data, headers, delay);
@@ -191,7 +195,7 @@ function _request(mod, url, data, headers, delay) {
     delay = parseInt(delay, 10);
   }
   delay = delay || 0;
-  mod.request = function (options, callback) {
+  getAgent(mod).request = function (options, callback) {
     var datas = [];
     if (!Array.isArray(data)) {
       datas = [data];
@@ -203,7 +207,7 @@ function _request(mod, url, data, headers, delay) {
 
     var match = matchURL(options, url);
     if (!match) {
-      return mod.__sourceRequest(options, callback);
+      return getAgent(mod).__sourceRequest(options, callback);
     }
 
     var req = mockRequest();
@@ -256,7 +260,7 @@ function _request(mod, url, data, headers, delay) {
  * @param {String|RegExp} url, request url path.
  * @param {String|Error} reqError, request error.
  * @param {String|Error} resError, response error.
- * @param {Number} [delay], request error delay time, default is 0.
+ * @param {Number} [delay], request error delay time, default is 10.
  */
 exports.http.requestError = function (url, reqError, resError, delay) {
   _requestError.call(this, http, url, reqError, resError, delay);
@@ -267,7 +271,7 @@ exports.http.requestError = function (url, reqError, resError, delay) {
  * @param {String|RegExp} url, request url path.
  * @param {String|Error} reqError, request error.
  * @param {String|Error} resError, response error.
- * @param {Number} [delay], request error delay time, default is 0.
+ * @param {Number} [delay], request error delay time, default is 10.
  */
 exports.https.requestError = function (url, reqError, resError, delay) {
   _requestError.call(this, https, url, reqError, resError, delay);
@@ -286,10 +290,10 @@ function _requestError(mod, url, reqError, resError, delay) {
     resError = new Error(resError);
     resError.name = 'MockHttpResponseError';
   }
-  mod.request = function (options, callback) {
+  getAgent(mod).request = function (options, callback) {
     var match = matchURL(options, url);
     if (!match) {
-      return mod.__sourceRequest(options, callback);
+      return getAgent(mod).__sourceRequest(options, callback);
     }
 
     var req = mockRequest();
@@ -347,8 +351,8 @@ exports.spawn = function (code, stdout, stderr, timeout) {
  * remove all mock effects.
  */
 exports.restore = function () {
-  http.request = http.__sourceRequest;
-  https.request = https.__sourceRequest;
+  getAgent(http).request = getAgent(http).__sourceRequest;
+  getAgent(https).request = getAgent(https).__sourceRequest;
   muk.restore();
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     }
   },
   "dependencies": {
-    "muk": ">=0.3.1"
+    "muk": ">=0.3.1",
+    "semver": "~2.2.1"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
In Node 0.11, a singleton named `globalAgent` in http.js
has been seperated from it. And http.get and http.request
are both rely on globalAgent.request.
