### PR TITLE
fix: types error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare function mm(target: any, key: string, prop: any): void;
 
 declare namespace mm {
-  // export interface MockMate extends mm;
+  // export MockMate type for egg-mock;
   type MockMate = typeof mm;
 
   type Request = (

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,73 +1,72 @@
+declare function mm(target: any, key: string, prop: any): void;
 
-export type Request = (
-    url: string | RegExp | { url: string, host: string}, 
-    data: any, 
-    headers?: object, 
-    delay?: number,
-) => MockMate;
+declare namespace mm {
+  // export interface MockMate extends mm;
+  type MockMate = typeof mm;
 
-export type RequestError = (
-    url: string | RegExp | { url: string, host: string}, 
-    reqError: string | Error, 
-    resError: string | Error, 
+  type Request = (
+    url: string | RegExp | { url: string; host: string },
+    data: any,
+    headers?: object,
     delay?: number
-) => MockMate;
+  ) => MockMate;
 
-export interface MockMate {
-    (target: any, key: string, prop: any): void;
-    /**
-     * Mock async function error.
-     */
-    error: (mod: any, method: string, error?: string | Error, props?: object, timeout?: number) => MockMate;
+  type RequestError = (
+    url: string | RegExp | { url: string; host: string },
+    reqError: string | Error,
+    resError: string | Error,
+    delay?: number
+  ) => MockMate;
 
-    /**
-     * mock return callback(null, data).
-     */
-    data: (mod: any, method: string, data: any, timeout?: number) => MockMate;
+  /**
+   * Mock async function error.
+   */
+  function error(mod: any, method: string, error?: string | Error, props?: object, timeout?: number): MockMate;
 
-    /**
-     * mock return callback(null, null).
-     */
-    empty: (mod: any, method: string, timeout?: number) => MockMate;
+  /**
+   * mock return callback(null, data).
+   */
+  function data(mod: any, method: string, data: any, timeout?: number): MockMate;
 
-    /**
-     * mock return callback(null, data1, data2).
-     */
-    datas: (mod: any, method: string, datas: any, timeout?: number) => MockMate;
+  /**
+   * mock return callback(null, null).
+   */
+  function empty(mod: any, method: string, timeout?: number): MockMate;
 
-    /**
-     * mock function sync throw error
-     */
-    syncError: (mod: any, method: string, error?: string | Error, props?: object) => void;
-    
-    /**
-     * mock function sync return data
-     */
-    syncData: (mod: any, method: string, data?: any) => void;
+  /**
+   * mock return callback(null, data1, data2).
+   */
+  function datas(mod: any, method: string, datas: any, timeout?: number): MockMate;
 
-    /**
-     * mock function sync return nothing
-     */
-    syncEmpty: (mod: any, method: string) => void;
+  /**
+   * mock function sync throw error
+   */
+  function syncError(mod: any, method: string, error?: string | Error, props?: object): void;
 
-    /**
-     * remove all mock effects.
-     */
-    restore: () => MockMate;
+  /**
+   * mock function sync return data
+   */
+  function syncData(mod: any, method: string, data?: any): void;
 
-    http: {
-        request: Request;
-        requestError: RequestError,
-    };
+  /**
+   * mock function sync return nothing
+   */
+  function syncEmpty(mod: any, method: string): void;
 
-    https: {
-        request: Request;
-        requestError: RequestError,
-    };
+  /**
+   * remove all mock effects.
+   */
+  function restore(): MockMate;
 
+  const http: {
+    request: Request;
+    requestError: RequestError;
+  };
+
+  const https: {
+    request: Request;
+    requestError: RequestError;
+  };
 }
-  
-declare const mm: MockMate;
-export = mm;
-export default mm;
 
+export = mm;


### PR DESCRIPTION
修复这个问题：https://github.com/node-modules/mm/commit/6a84a0a9c01a8e68e08eb63b4d587b73cb8fd74a#r30293552

之前在 https://github.com/eggjs/egg-mock/pull/81#issuecomment-411335563 中提议让 @paranoidjk  改成了基于 interface 的模式，在本机中验证时忘记项目中设置了 `skipLibCheck` （ 设置了这个会忽略报错 ），但是其实这么写声明是有问题的，ts 是不允许使用 `exports = ` 的同时也使用 esmodule 的 export。

现在还是改回传统的 namespace 模式，不过可以在 namespace 中 export 一个 `MockMate` 的 type，而在 ts 2.2 版本之后，interface 是可以 extend type 的，所以对于 egg-mock 是没影响。