### PR TITLE
fix: do function type check after execute

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -11,21 +11,11 @@ const Readable = require('stream').Readable;
 const Duplex = require('stream').Duplex;
 
 const mock = module.exports = function mock(target, property, value) {
-  checkFunctionType(target, property, value);
-  value = spyFunction(value);
+  value = spyFunction(target, property, value);
   return muk(target, property, value);
 };
 
-function checkFunctionType(target, property, value) {
-  if (typeof target[property] === 'function' && typeof value === 'function') {
-    // don't mock async function to normal function
-    if (is.asyncFunction(target[property]) && !is.asyncFunction(value)) {
-      throw TypeError('Can\'t mock async function to normal function');
-    }
-  }
-}
-
-function spyFunction(fn) {
+function spyFunction(target, property, fn) {
   if (!is.function(fn)) return fn;
   if (is.asyncFunction(fn)) {
     const spy = async function(...args) {
@@ -51,15 +41,28 @@ function spyFunction(fn) {
     return spy;
   }
 
+  // don't allow mock async function to common function
+  const isAsyncLike = isAsyncLikeFunction(target, property);
   const spy = function(...args) {
     spy.called = spy.called || 0;
     spy.calledArguments = spy.calledArguments || [];
     spy.calledArguments.push(args);
     spy.lastCalledArguments = args;
     spy.called++;
-    return fn.call(this, ...args);
+    const res = fn.call(this, ...args);
+    if (isAsyncLike && !is.promise(res)) {
+      throw new Error(`Can\'t mock async function to normal function for property "${property}"`);
+    }
+    return res;
   };
   return spy;
+}
+
+function isAsyncLikeFunction(target, property) {
+  // don't call getter
+  // Object.getOwnPropertyDescriptor can't find getter in prototypes
+  if (target.__lookupGetter__(property)) return false;
+  return is.asyncFunction(target[property]) || is.generatorFunction(target[property]);
 }
 
 exports = mock;

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -7,6 +7,9 @@ describe('test/async-await.test.js', () => {
     async request() {
       return 'yes';
     },
+    * generatorRequest() {
+      return 'yes';
+    },
   };
 
   afterEach(mm.restore);
@@ -34,6 +37,30 @@ describe('test/async-await.test.js', () => {
         throw new Error('should not run this');
       } catch (err) {
         err.message.should.equal('Can\'t mock async function to normal function for property "request"');
+      }
+    });
+
+    it('should mock generator function to normal throw type error', async () => {
+      try {
+        mm(foo, 'generatorRequest', () => {
+          return 'no';
+        });
+        foo.generatorRequest();
+        throw new Error('should not run this');
+      } catch (err) {
+        err.message.should.equal('Can\'t mock async function to normal function for property "generatorRequest"');
+      }
+    });
+
+    it('should mock async function to normal function return promise should work', async () => {
+      try {
+        mm(foo, 'request', () => {
+          return Promise.resolve('no');
+        });
+        foo.request();
+        throw new Error('should not run this');
+      } catch (err) {
+        err.message.should.equal('should not run this');
       }
     });
   });

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -30,9 +30,10 @@ describe('test/async-await.test.js', () => {
         mm(foo, 'request', () => {
           return 'no';
         });
+        foo.request();
         throw new Error('should not run this');
       } catch (err) {
-        err.message.should.equal('Can\'t mock async function to normal function');
+        err.message.should.equal('Can\'t mock async function to normal function for property "request"');
       }
     });
   });


### PR DESCRIPTION
换一种实现，如果将异步方法 mock 成了同步方法，在执行完之后发现如果未返回 promise 则抛错。