### PR TITLE
fix: 支持 jest.fn 的 mock 用法

### DIFF
--- a/lib/mm.js
+++ b/lib/mm.js
@@ -17,6 +17,8 @@ const mock = module.exports = function mock(target, property, value) {
 
 function spyFunction(target, property, fn) {
   if (!is.function(fn)) return fn;
+  // support mock with jest.fn()
+  if (fn._isMockFunction && fn.mock) return fn;
   if (is.asyncFunction(fn)) {
     const spy = async function(...args) {
       spy.called = spy.called || 0;

--- a/test/mm.test.js
+++ b/test/mm.test.js
@@ -1068,6 +1068,24 @@ describe('test/mm.test.js', () => {
       target.add.calledArguments.should.eql([[ 1, 1 ], [ 2, 2 ]]);
       target.add.lastCalledArguments.should.eql([ 2, 2 ]);
     });
+
+    it('should ignore jest.fn()', () => {
+      const target = {
+        add(a, b) {
+          return a + b;
+        },
+      };
+
+      function mockAdd() {
+        return 3;
+      }
+      mockAdd._isMockFunction = true;
+      mockAdd.mock = {};
+      mm(target, 'add', mockAdd);
+      target.add(1, 1).should.equal(3);
+      target.add(2, 2).should.equal(3);
+      assert(target.add === mockAdd);
+    });
   });
 });
 


### PR DESCRIPTION
```
mock(app, 'testFunction', jest.fn());
```

这个场景不需要 spy，会用 jest 相关的校验函数